### PR TITLE
feat: implement auto-stop containers after 60s idle + chat history pe…

### DIFF
--- a/src/components/setup/ContainerStartupDisplay.tsx
+++ b/src/components/setup/ContainerStartupDisplay.tsx
@@ -1,0 +1,415 @@
+import { useState, useEffect, useRef } from "react";
+import { Loader2, AlertTriangle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+interface ContainerStartupDisplayProps {
+  projectId: string;
+  reason?: "initial" | "restart"; // "initial" for first startup, "restart" for comeback
+}
+
+interface CurrentEvent {
+  type: "message" | "tool";
+  text: string;
+  isStreaming?: boolean;
+}
+
+interface QueueStatusResponse {
+  projectId: string;
+  currentStep: number;
+  setupJobs: Record<string, unknown>;
+  hasError: boolean;
+  errorMessage: string | undefined;
+  isSetupComplete: boolean;
+  promptSentAt: number | undefined;
+  jobTimeoutWarning: string | undefined;
+}
+
+const TOTAL_STEPS = 2;
+
+// Two steps only for container startup
+const STEPS: Array<{ step: number; label: string }> = [
+  { step: 1, label: "Docker" },
+  { step: 2, label: "Agent" },
+];
+
+// Descriptions for each step
+const STEP_DESCRIPTIONS: Record<number, string> = {
+  1: "Starting containers...",
+  2: "Initializing AI agent...",
+};
+
+export function ContainerStartupDisplay({
+  projectId,
+  reason = "initial",
+}: ContainerStartupDisplayProps) {
+  const [isComplete, setIsComplete] = useState(false);
+  const [currentEvent, setCurrentEvent] = useState<CurrentEvent | null>(null);
+  const [isTransitioning, setIsTransitioning] = useState(false);
+  const [currentStep, setCurrentStep] = useState(1);
+  const [startupError, setStartupError] = useState<string | null>(null);
+  const [jobTimeoutWarning, setJobTimeoutWarning] = useState<string | null>(null);
+  const [sessionsLoaded, setSessionsLoaded] = useState(false);
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const transitionTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const startTimeRef = useRef<number>(Date.now());
+
+  // Connect to opencode event stream to show progress
+  useEffect(() => {
+    if (isComplete) return;
+
+    // Open SSE connection to opencode events
+    const eventSource = new EventSource(
+      `/api/projects/${projectId}/opencode/event`
+    );
+    eventSourceRef.current = eventSource;
+
+    eventSource.addEventListener("chat.event", (e) => {
+      try {
+        const event = JSON.parse(e.data);
+        handleOpencodeEvent(event);
+      } catch {
+        // Ignore parse errors
+      }
+    });
+
+    eventSource.onerror = () => {
+      eventSource.close();
+    };
+
+    return () => {
+      if (eventSourceRef.current === eventSource) {
+        eventSource.close();
+        eventSourceRef.current = null;
+      }
+    };
+  }, [projectId, isComplete]);
+
+  const handleOpencodeEvent = (event: {
+    type: string;
+    payload: Record<string, unknown>;
+  }) => {
+    const { type, payload } = event;
+
+    switch (type) {
+      case "chat.message.delta": {
+        const { deltaText } = payload as {
+          messageId: string;
+          deltaText: string;
+        };
+
+        setCurrentEvent((prev) => {
+          if (prev?.type === "message") {
+            return {
+              ...prev,
+              text: prev.text + deltaText,
+              isStreaming: true,
+            };
+          }
+
+          return {
+            type: "message",
+            text: deltaText,
+            isStreaming: true,
+          };
+        });
+        // Advance to agent step when we start streaming agent messages
+        setCurrentStep(2);
+        break;
+      }
+
+      case "chat.message.final": {
+        setCurrentEvent((prev) => {
+          if (prev?.type === "message") {
+            return { ...prev, isStreaming: false };
+          }
+          return prev;
+        });
+        break;
+      }
+
+      case "chat.tool.start": {
+        const { name, input } = payload as {
+          name: string;
+          input: unknown;
+        };
+
+        const inputObj = (input as Record<string, unknown>) || {};
+        const filePath = typeof inputObj.filePath === "string" 
+          ? inputObj.filePath 
+          : typeof inputObj.path === "string" 
+          ? inputObj.path 
+          : null;
+        const fileName = filePath ? filePath.split("/").pop() : null;
+
+        const toolDescriptions: Record<string, string> = {
+          "read": "Reading",
+          "write": "Creating",
+          "edit": "Editing",
+          "delete": "Deleting",
+          "list": "Listing",
+          "bash": "Running",
+          "glob": "Finding files",
+        };
+
+        const action = toolDescriptions[name] || name.charAt(0).toUpperCase() + name.slice(1);
+        const friendlyText = fileName ? `${action} ${fileName}...` : `${action}...`;
+
+        // Fade transition to new tool
+        setIsTransitioning(true);
+        if (transitionTimeoutRef.current) {
+          clearTimeout(transitionTimeoutRef.current);
+        }
+        transitionTimeoutRef.current = setTimeout(() => {
+          setCurrentEvent({
+            type: "tool",
+            text: friendlyText,
+            isStreaming: true,
+          });
+          setIsTransitioning(false);
+        }, 300);
+        break;
+      }
+
+      case "chat.tool.finish": {
+        setCurrentEvent((prev) => {
+          if (prev?.type === "tool") {
+            return { ...prev, isStreaming: false };
+          }
+          return prev;
+        });
+        break;
+      }
+
+      case "chat.tool.error": {
+        setCurrentEvent((prev) => {
+          if (prev?.type === "tool") {
+            return { ...prev, isStreaming: false };
+          }
+          return prev;
+        });
+        break;
+      }
+
+      case "setup.complete": {
+        // Event stream signals that initial prompt was completed
+        setIsComplete(true);
+        setCurrentStep(2);
+        break;
+      }
+    }
+  };
+
+  // Poll queue status for container startup progress
+  useEffect(() => {
+    if (isComplete) return;
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+
+    const poll = async () => {
+      try {
+        const response = await fetch(`/api/projects/${projectId}/queue-status`);
+
+        if (!response.ok) {
+          setStartupError("Failed to check startup status");
+          return;
+        }
+
+        const data = (await response.json()) as QueueStatusResponse;
+
+        // For container startup, map the queue status steps:
+        // Step 1-2 = Docker (containers starting)
+        // Step 3+ = Agent (opencode initializing)
+        if (data.currentStep >= 3) {
+          setCurrentStep(2);
+        } else {
+          setCurrentStep(1);
+        }
+
+        // Check for queue job failures
+        if (data.hasError) {
+          setStartupError(data.errorMessage || "Startup failed");
+          return;
+        }
+
+        // Show queue job timeout warning
+        if (data.jobTimeoutWarning) {
+          setJobTimeoutWarning(data.jobTimeoutWarning);
+        }
+
+        // When we reach step 5, the container is fully ready
+        // But if restarting, also wait for sessions to load
+        const shouldWaitForSessions = reason === "restart";
+        const sessionConditionMet = !shouldWaitForSessions || sessionsLoaded;
+
+        if (data.currentStep >= 5 && data.isSetupComplete && sessionConditionMet) {
+          // Wait a moment for the UI to show final state, then signal completion
+          setTimeout(() => {
+            setIsComplete(true);
+          }, 1000);
+        }
+      } catch (error) {
+        console.error("Failed to poll queue status:", error);
+      }
+    };
+
+    // Adaptive polling: faster at first, slower later
+    const elapsed = Date.now() - startTimeRef.current;
+    const pollCount = Math.floor(elapsed / 500);
+
+    let pollInterval = 2000;
+    if (pollCount < 3) pollInterval = 500;
+    else if (pollCount < 13) pollInterval = 1000;
+
+    // Check for timeout (30 seconds)
+    if (elapsed > 30_000 && !startupError) {
+      setStartupError("Timeout waiting for containers to start");
+      return;
+    }
+
+    intervalId = setInterval(poll, pollInterval);
+    // Run first poll immediately
+    poll();
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [projectId, isComplete, startupError, sessionsLoaded]);
+
+  // Poll for persisted session loading (only on restart)
+  useEffect(() => {
+    if (reason !== "restart" || sessionsLoaded || isComplete) return;
+
+    let intervalId: ReturnType<typeof setInterval> | null = null;
+    const sessionCheckStartTime = Date.now();
+
+    const pollSessions = async () => {
+      try {
+        const response = await fetch(`/api/projects/${projectId}/opencode/session`);
+        if (!response.ok) return;
+
+        const data = await response.json();
+        const sessions = (data.sessions || data || []) as unknown[];
+
+        // If we have at least one session, mark as loaded
+        if (Array.isArray(sessions) && sessions.length > 0) {
+          setSessionsLoaded(true);
+          return;
+        }
+
+        // Timeout after 30s - assume sessions are loaded or don't exist
+        const elapsed = Date.now() - sessionCheckStartTime;
+        if (elapsed > 30_000) {
+          setSessionsLoaded(true);
+        }
+      } catch (error) {
+        console.error("Failed to check session loading:", error);
+      }
+    };
+
+    // Poll every 500ms for sessions
+    intervalId = setInterval(pollSessions, 500);
+    pollSessions(); // Check immediately
+
+    return () => {
+      if (intervalId) clearInterval(intervalId);
+    };
+  }, [projectId, reason, sessionsLoaded, isComplete]);
+
+  const displayMessage = 
+    currentEvent?.type === "tool" 
+      ? currentEvent?.text
+      : currentEvent?.type === "message"
+      ? currentEvent?.text
+      : jobTimeoutWarning
+      ? jobTimeoutWarning
+      : reason === "restart" && !sessionsLoaded && currentStep >= 2
+      ? "Loading your chat history..."
+      : STEP_DESCRIPTIONS[currentStep] ?? "Starting your environment...";
+  
+  const hasError = startupError !== null;
+  const heading = reason === "restart" 
+    ? "Your environment was stopped. Restarting..." 
+    : "Starting your environment...";
+
+  return (
+    <div className="flex-1 flex items-center justify-center px-4">
+      <div className="flex flex-col items-center gap-8 w-full max-w-2xl">
+        <div className="text-center space-y-6 w-full">
+          <h2 className="text-2xl font-semibold">
+            {hasError ? "Failed to Start Environment" : heading}
+          </h2>
+
+          {!hasError ? (
+            <div className="space-y-4">
+              {/* Timeline of steps */}
+              <div className="flex items-center justify-between gap-1 w-full">
+                {STEPS.map((step) => {
+                  const isCompleted = currentStep > step.step;
+                  const isCurrent = currentStep === step.step;
+
+                  return (
+                    <div key={step.step} className="flex flex-col items-center gap-2 flex-1">
+                      <div
+                        className={`w-8 h-8 rounded-full flex items-center justify-center text-xs font-medium transition-all ${
+                          isCurrent
+                            ? "bg-primary text-primary-foreground ring-2 ring-primary ring-offset-2"
+                            : isCompleted
+                            ? "bg-primary/20 text-primary"
+                            : "bg-secondary text-muted-foreground"
+                        }`}
+                      >
+                        {isCompleted ? "✓" : step.step}
+                      </div>
+                      <span className={`text-xs font-medium line-clamp-1 ${
+                        isCurrent ? "text-primary" : "text-muted-foreground"
+                      }`}>
+                        {step.label}
+                      </span>
+                    </div>
+                  );
+                })}
+              </div>
+
+              {/* Progress bar */}
+              <div className="w-full h-1.5 bg-secondary rounded-full overflow-hidden">
+                <div 
+                  className="h-full bg-primary transition-all duration-300 ease-out"
+                  style={{ width: `${(currentStep / TOTAL_STEPS) * 100}%` }}
+                />
+              </div>
+
+              {/* Status message */}
+              <div className={`flex items-center justify-center gap-2 min-h-6 transition-opacity duration-300 ${
+                isTransitioning ? "opacity-0" : "opacity-100"
+              }`}>
+                <Loader2 className="h-4 w-4 animate-spin text-primary flex-shrink-0" />
+                <p className="text-sm text-muted-foreground">
+                  {displayMessage}
+                </p>
+              </div>
+            </div>
+          ) : (
+            // Error state
+            <div className="space-y-4">
+              <div className="flex justify-center">
+                <AlertTriangle className="h-12 w-12 text-red-500" />
+              </div>
+              <div className="p-4 bg-red-50 border border-red-200 rounded-lg text-left">
+                <p className="text-sm text-red-800 break-words">
+                  <span className="font-semibold">Error: </span>
+                  {startupError}
+                </p>
+              </div>
+              <Button
+                onClick={() => window.location.reload()}
+                variant="outline"
+              >
+                Retry Startup
+              </Button>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
…rsistence on restart

- Add 60-second idle timeout to presence manager: containers auto-stop after no heartbeats
- Presence reaper stops idle containers, heartbeats reset the timer
- Re-initialize opencode sessions after container restart if persisted sessions are lost
- Add ContainerStartupDisplay component: shows 2-step progress (Docker → Agent) during startup
- Detect when sessions are loaded from disk before showing chat UI
- Show 'Loading your chat history...' message during restart waits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Real-time container startup progress visualization with step tracking and status updates
  * Automatic container shutdown after 60 seconds of inactivity when no active users are present
  * Error handling with retry options during startup failures

* **Improvements**
  * Enhanced session restoration following container restarts to prevent data loss

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->