### PR TITLE
Fix production deployments showing preview URLs

### DIFF
--- a/src/actions/projects.ts
+++ b/src/actions/projects.ts
@@ -538,9 +538,13 @@ export const projects = {
 				// Symlink update failed, but container is running
 			}
 
+			const { getCanonicalProductionUrl } = await import(
+				"@/server/productions/productionUrl"
+			);
 			await updateProductionStatus(input.projectId, "running", {
 				productionHash: input.toHash,
 				productionStartedAt: new Date(),
+				productionUrl: await getCanonicalProductionUrl(project),
 			});
 
 			return { success: true };

--- a/src/server/live/manager.ts
+++ b/src/server/live/manager.ts
@@ -10,6 +10,7 @@
  */
 
 import { logger } from "@/server/logger";
+import { repairStaleProductionUrl } from "@/server/productions/productionUrl";
 import {
 	getActiveProductionJob,
 	getProductionStatus,
@@ -275,7 +276,10 @@ async function buildState(
 			getActiveProductionJob(projectId),
 		]);
 
-	const production = getProductionStatus(project);
+	const production = {
+		...getProductionStatus(project),
+		url: await repairStaleProductionUrl(project),
+	};
 
 	const productionState: ProductionLiveState = {
 		status: production.status,

--- a/src/server/productions/productionUrl.ts
+++ b/src/server/productions/productionUrl.ts
@@ -1,0 +1,37 @@
+import type { Project } from "@/server/db/schema";
+import { updateProductionStatus } from "@/server/productions/productions.model";
+import { getTailscaleProjectUrl } from "@/server/tailscale/urls";
+
+export async function getCanonicalProductionUrl(
+	project: Pick<Project, "id" | "slug" | "productionPort">,
+): Promise<string> {
+	const tailscaleUrl = await getTailscaleProjectUrl(
+		project.slug,
+		"production",
+		project.id,
+	);
+
+	return tailscaleUrl ?? `http://localhost:${project.productionPort}`;
+}
+
+export async function repairStaleProductionUrl(
+	project: Pick<
+		Project,
+		"id" | "slug" | "productionPort" | "productionStatus" | "productionUrl"
+	>,
+): Promise<string | null> {
+	if (project.productionStatus !== "running") {
+		return project.productionUrl;
+	}
+
+	const canonicalUrl = await getCanonicalProductionUrl(project);
+	if (project.productionUrl === canonicalUrl) {
+		return canonicalUrl;
+	}
+
+	await updateProductionStatus(project.id, project.productionStatus, {
+		productionUrl: canonicalUrl,
+	});
+
+	return canonicalUrl;
+}

--- a/src/server/queue/handlers/productionStop.ts
+++ b/src/server/queue/handlers/productionStop.ts
@@ -51,7 +51,10 @@ export function handleProductionStop(
 
 		if (project.status !== "deleting") {
 			yield* Effect.tryPromise({
-				try: () => updateProductionStatus(project.id, "stopped"),
+				try: () =>
+					updateProductionStatus(project.id, "stopped", {
+						productionUrl: null,
+					}),
 				catch: (error) =>
 					new ProjectError({
 						projectId: project.id,

--- a/src/server/queue/handlers/productionWaitReady.ts
+++ b/src/server/queue/handlers/productionWaitReady.ts
@@ -9,6 +9,7 @@ import {
 } from "@/server/health/checkHealthEndpoint";
 import { logger } from "@/server/logger";
 import { cleanupOldProductionVersions } from "@/server/productions/cleanup";
+import { getCanonicalProductionUrl } from "@/server/productions/productionUrl";
 import {
 	getPreviousReleaseHash,
 	updateProductionStatus,
@@ -108,17 +109,10 @@ export function handleProductionWaitReady(
 		if (productionReady) {
 			yield* promoteRelease(project.id, payload.productionHash);
 
-			const tailscaleUrl = yield* Effect.tryPromise({
-				try: async () => {
-					const { getTailscaleProjectUrl } = await import(
-						"@/server/tailscale/urls"
-					);
-					return getTailscaleProjectUrl(project.slug, "production", project.id);
-				},
-				catch: () => null as null,
-			}).pipe(Effect.catchAll(() => Effect.succeed(null as string | null)));
-			const productionUrl =
-				tailscaleUrl ?? `http://localhost:${payload.productionPort}`;
+			const productionUrl = yield* Effect.tryPromise({
+				try: () => getCanonicalProductionUrl(project),
+				catch: () => `http://localhost:${payload.productionPort}`,
+			});
 			yield* Effect.tryPromise({
 				try: () =>
 					updateProductionStatus(project.id, "running", {


### PR DESCRIPTION
## Summary
- centralize canonical production URL generation
- persist the correct production URL after deploys and rollbacks
- automatically repair stale stored production URLs in live state
- clear stored production URL when production is stopped

## Testing
- not run locally in this checkout (`node_modules` missing, so `pnpm format` / typecheck could not be executed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved production URL reliability with automatic repair and validation when production is running.
  * Fixed missing URL information when production status is updated; URLs are now consistently tracked and cleared when production stops.
  * Enhanced URL resolution with fallback mechanism for offline environments, ensuring production connectivity remains stable during state transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->