### PR TITLE
feat(ci): use GitHub Deployments API for PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -87,7 +87,7 @@ jobs:
       github.event.action != 'closed'
     permissions:
       contents: read
-      pull-requests: write
+      deployments: write
     env:
       GH_TOKEN: ${{ github.token }}
 
@@ -127,6 +127,29 @@ jobs:
       - name: Extract PR number
         id: pr
         run: echo "number=${{ github.event.number }}" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub deployment
+        id: gh-deployment
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.event.pull_request.head.sha }}
+          PR_NUM: ${{ github.event.number }}
+        run: |
+          DEPLOYMENT_ID=$(jq -n \
+            --arg ref "$SHA" \
+            --arg env "pr-$PR_NUM" \
+            --arg desc "Preview for PR #$PR_NUM" \
+            '{ref:$ref, environment:$env, description:$desc, auto_merge:false, required_contexts:[], transient_environment:true, production_environment:false}' \
+            | gh api --method POST \
+              -H "Accept: application/vnd.github+json" \
+              repos/${{ github.repository }}/deployments \
+              --input - \
+              --jq '.id')
+          echo "id=$DEPLOYMENT_ID" >> "$GITHUB_OUTPUT"
+          gh api --method POST \
+            repos/${{ github.repository }}/deployments/$DEPLOYMENT_ID/statuses \
+            -f state=in_progress \
+            -f description="Deploying preview..."
 
       - name: Setup SSH agent
         uses: webfactory/ssh-agent@v0.9.0
@@ -276,29 +299,28 @@ jobs:
           echo "✅ PR preview deployed successfully!"
           echo "port=$PORT" >> "$GITHUB_OUTPUT"
 
-      - name: Comment preview URL
+      - name: Mark deployment success
         if: success()
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUM=${{ steps.pr.outputs.number }}
           PORT=${{ steps.deploy.outputs.port }}
           PREVIEW_URL="http://doce.pangolin-frog.ts.net:$PORT"
-          MARKER="<!-- doce-preview-status -->"
-          BODY="🚀 **Preview deployed!**<br><br>[Open preview environment]($PREVIEW_URL)<br><br>**Note:** Accessible via Tailscale network<br><br>ℹ️ This preview will be automatically cleaned up when the PR is closed."
+          gh api --method POST \
+            repos/${{ github.repository }}/deployments/${{ steps.gh-deployment.outputs.id }}/statuses \
+            -f state=success \
+            -f environment_url="$PREVIEW_URL" \
+            -f description="Preview deployed"
 
-          ./scripts/upsert-pr-comment.sh "$MARKER" "$BODY" "$PR_NUM"
-
-      - name: Comment on failure
-        if: failure()
+      - name: Mark deployment failure
+        if: failure() && steps.gh-deployment.outputs.id != ''
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          PR_NUM=${{ steps.pr.outputs.number }}
-          MARKER="<!-- doce-preview-status -->"
-          BODY="❌ **Preview deployment failed.**<br><br>Check the [workflow logs](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details."
-
-          ./scripts/upsert-pr-comment.sh "$MARKER" "$BODY" "$PR_NUM"
+          gh api --method POST \
+            repos/${{ github.repository }}/deployments/${{ steps.gh-deployment.outputs.id }}/statuses \
+            -f state=failure \
+            -f description="Preview deployment failed"
 
   teardown:
     name: Cleanup PR Preview
@@ -306,6 +328,7 @@ jobs:
     if: github.event.action == 'closed'
     permissions:
       contents: read
+      deployments: write
 
     steps:
       - name: Clean Tailscale cache
@@ -366,4 +389,19 @@ jobs:
           ssh -o StrictHostKeyChecking=no "$SSH_USER@$VM_HOST" "rm -rf \"$PR_DIR\" 2>/dev/null || true"
 
           echo "✅ PR preview cleaned up!"
+
+      - name: Deactivate GitHub deployments
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUM: ${{ steps.pr.outputs.number }}
+        run: |
+          ENV_NAME="pr-$PR_NUM"
+          DEPLOYMENTS=$(gh api "repos/${{ github.repository }}/deployments?environment=$ENV_NAME" --jq '.[].id')
+          for id in $DEPLOYMENTS; do
+            gh api --method POST \
+              repos/${{ github.repository }}/deployments/$id/statuses \
+              -f state=inactive \
+              -f description="PR closed" || true
+          done
+          gh api --method DELETE "repos/${{ github.repository }}/environments/$ENV_NAME" 2>/dev/null || true
 

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -264,6 +264,9 @@ jobs:
             echo "⏱️ Build completed at $(date)"
           else
             echo "📥 Pulling pre-built image from registry (Dockerfile unchanged)..."
+            # Drop any stale ghcr.io credentials so public pulls fall back to anonymous
+            ssh -o StrictHostKeyChecking=no "$SSH_USER@$VM_HOST" \
+              "docker logout ghcr.io 2>/dev/null || true"
             ssh -o StrictHostKeyChecking=no "$SSH_USER@$VM_HOST" \
               "docker pull ghcr.io/${{ github.repository_owner }}/doce.dev:latest && \
                docker tag ghcr.io/${{ github.repository_owner }}/doce.dev:latest doce-pr-$PR_NUM:latest"


### PR DESCRIPTION
Replaces the PR comment with native GitHub Deployments UI (the rocket/environments panel that Vercel uses). Posts in_progress, success (with environment_url), failure, and inactive statuses, and deletes the pr-N environment on teardown.
