### PR TITLE
debug: add logging to update check digest comparison

### DIFF
--- a/src/actions/update.ts
+++ b/src/actions/update.ts
@@ -170,6 +170,7 @@ export const update = {
 
 				if (isCacheValid(versionCache.remote)) {
 					const localDigest = await getLocalImageDigest();
+					logger.info({ localDigest, cachedRemoteDigest: versionCache.remote?.digest }, "Comparing digests (cache hit)");
 					const hasUpdate = localDigest !== versionCache.remote?.digest;
 					return {
 						hasUpdate,
@@ -197,6 +198,7 @@ export const update = {
 				}
 
 				const localDigest = await getLocalImageDigest();
+				logger.info({ localDigest, remoteDigest: remoteInfo.digest }, "Comparing digests");
 				const hasUpdate = localDigest !== remoteInfo.digest;
 
 				return {


### PR DESCRIPTION
Add logging to help diagnose why `hasUpdate` still returns true even when running the latest image.

This will log the actual local and remote digest values being compared so we can see why they don't match.