### PR TITLE
debug: use template strings for update check logging

### DIFF
--- a/src/actions/update.ts
+++ b/src/actions/update.ts
@@ -170,7 +170,7 @@ export const update = {
 
 				if (isCacheValid(versionCache.remote)) {
 					const localDigest = await getLocalImageDigest();
-					logger.info({ localDigest, cachedRemoteDigest: versionCache.remote?.digest }, "Comparing digests (cache hit)");
+					logger.info(`Comparing digests (cache hit): local=${localDigest} remote=${versionCache.remote?.digest}`);
 					const hasUpdate = localDigest !== versionCache.remote?.digest;
 					return {
 						hasUpdate,
@@ -198,7 +198,7 @@ export const update = {
 				}
 
 				const localDigest = await getLocalImageDigest();
-				logger.info({ localDigest, remoteDigest: remoteInfo.digest }, "Comparing digests");
+				logger.info(`Comparing digests: local=${localDigest} remote=${remoteInfo.digest}`);
 				const hasUpdate = localDigest !== remoteInfo.digest;
 
 				return {


### PR DESCRIPTION
Fixes the logging from #52 - the object-style logger.info() wasn't showing values in production logs. Uses template strings instead so we can actually see the digest values being compared.